### PR TITLE
fwdControl: fix bug when seasons provided in FLQuant - do not drop seasons

### DIFF
--- a/R/coerce.R
+++ b/R/coerce.R
@@ -103,7 +103,7 @@ setAs("FLQuants", "fwdControl",
     names(df) <- sub("qname", "quant", names(df))
 
     # DROP season if not used
-    if(length(unique(df$season)) == 1)
+    if(identical(unique(df$season), "all"))
       df$season <- NULL
 
 		# NO ITERS

--- a/R/coerce.R
+++ b/R/coerce.R
@@ -117,7 +117,7 @@ setAs("FLQuants", "fwdControl",
     # ITERS
 		} else {
 
-			target <- cbind(df[df$iter == df$iter[1],][,c('year', 'quant')])
+			target <- cbind(df[df$iter == df$iter[1],][,c('year', 'season', 'quant')])
 	
       # ARRAY iters [targets, 3, iters]    
       iters <- array(NA, dim=c(dim(target)[1], 3, its),


### PR DESCRIPTION
There was a bug when a fwdControl object included seasons and iterations. This simple example fails:
```
as(FLQuants(fbar = FLQuant(1, dimnames = list(year = 1, season = 1:4, iter = 1:2))), "fwdControl") # fails
# Error in ix[, c(1, 3), ][is.na(ix[, c(1, 3), ])] <- iy[, c(1, 3), ][!is.na(iy[,  : 
#   replacement has length zero 
```

The issue was that the function coercing FLQuant to fwdControl dropped seasons. With the fix, the code above runs:
```
as(FLQuants(fbar = FLQuant(1, dimnames = list(year = 1, season = 1:4, iter = 1:2))), "fwdControl") # works
# An object of class "fwdControl"
#  (step) year quant season biol min value max
#       1    1  fbar      1    1  NA 1.000  NA
#       2    1  fbar      2    1  NA 1.000  NA
#       3    1  fbar      3    1  NA 1.000  NA
#       4    1  fbar      4    1  NA 1.000  NA
#    iters:  2
```

Note: This pull request is for the "fix_seasons" branch because the latest commits in master https://github.com/flr/FLasher/commit/39fb97ccc28e1bd4ddfa16c51a719cbebcc7f938 8980c539bc099e6d49999e2578d6733a209bdfff cause R to crash when fwd() is run with iterations and seasons.